### PR TITLE
Documentation tweak

### DIFF
--- a/builder/README.md
+++ b/builder/README.md
@@ -37,10 +37,10 @@ docker run -it --rm --cap-add=SYS_ADMIN lighthouse_ci https://example.com
 
 
 # Audits example.com and saves HTML report to a file.
-docker run -it --rm --cap-add=SYS_ADMIN lighthouse_ci --quiet https://example.com > report.html
+docker run -it --rm --cap-add=SYS_ADMIN lighthouse_ci https://example.com --quiet > report.html
 
 # Audits example.com and saves JSON results to a file.
-docker run -it --rm --cap-add=SYS_ADMIN lighthouse_ci --quiet --output=json https://example.com > report.json
+docker run -it --rm --cap-add=SYS_ADMIN lighthouse_ci https://example.com --quiet --output=json > report.json
 
 # Print Lighthouse version used in the container.
 docker run -it --rm --cap-add=SYS_ADMIN lighthouse_ci --version


### PR DESCRIPTION
After `cd`ing into `builder/` and doing `yarn build`, if we run the container-as-CLI command as it is currently documented, the argument order is slightly busted and the test doesn't run:

```
$ docker run -it --rm --cap-add=SYS_ADMIN lighthouse_ci --quiet --output=json https://example.com > report.json
$ head report.json
Please provide a url

Specify --help for available options
```
If we rearrange so the LH flags come after the url, the test runs and we get the expected json result:
```
$ docker run -it --rm --cap-add=SYS_ADMIN lighthouse_ci https://example.com --quiet --output=json > report.json
$ head report.json
{
  "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/73.0.3679.0 Safari/537.36",
  "environment": {
    "networkUserAgent": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3559.0 Mobile Safari/537.36",
    "hostUserAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/73.0.3679.0 Safari/537.36",
    "benchmarkIndex": 926
  },
  "lighthouseVersion": "4.1.0",
  "fetchTime": "2019-01-29T23:06:18.883Z",
  "requestedUrl": "https://example.com/",
```
This PR is a minor documentation tweak to reflect that :) 