### PR TITLE
Support LIGHTHOUSE_BUILDER_HOST env variable in frontend server

### DIFF
--- a/frontend/lighthouse-ci.js
+++ b/frontend/lighthouse-ci.js
@@ -20,6 +20,8 @@ const Github = require('@octokit/rest');
 const URL = require('url').URL;
 const URLSearchParams = require('url').URLSearchParams;
 
+const LIGHTHOUSE_BUILDER_HOST = process.env.LIGHTHOUSE_BUILDER_HOST || 'https://builder-dot-lighthouse-ci.appspot.com';
+
 class LighthouseCI {
   /**
    * @param {!string} token Github OAuth token that has repo:status access.
@@ -44,7 +46,7 @@ class LighthouseCI {
 
     // POST https://builder-dot-lighthouse-ci.appspot.com/ci
     // '{"output": "json", "url": <testUrl>}"'
-    return fetch('https://builder-dot-lighthouse-ci.appspot.com/ci', {
+    return fetch(`${LIGHTHOUSE_BUILDER_HOST}/ci`, {
       method: 'POST',
       body: JSON.stringify(body),
       headers


### PR DESCRIPTION
Currently the frontend server is hardcoded to use the builder at `https://builder-dot-lighthouse-ci.appspot.com`, which is not customizable (except editing the code directly) for when running a custom instance of the builder.

This PR makes the URL to the builder configurable through the `LIGHTHOUSE_BUILDER_HOST` environment variable.

```bash
# in lighthousebot/frontend
LIGHTHOUSE_BUILDER_HOST=https://my-custom-builder.com yarn start
```